### PR TITLE
Scale utils, bidirectional adapters

### DIFF
--- a/src/adapter/BaseAdapter.sol
+++ b/src/adapter/BaseAdapter.sol
@@ -4,6 +4,9 @@ pragma solidity 0.8.23;
 import {IPriceOracle} from "src/interfaces/IPriceOracle.sol";
 import {Errors} from "src/lib/Errors.sol";
 
+/// @title BaseAdapter
+/// @author Euler Labs (https://www.eulerlabs.com/)
+/// @notice Abstract adapter with virtual bid/ask pricing.
 abstract contract BaseAdapter is IPriceOracle {
     /// @inheritdoc IPriceOracle
     function getQuote(uint256 inAmount, address base, address quote) external view returns (uint256) {
@@ -11,11 +14,11 @@ abstract contract BaseAdapter is IPriceOracle {
     }
 
     /// @inheritdoc IPriceOracle
-    /// @dev Does not support true bid-ask pricing.
+    /// @dev Does not support true bid/ask pricing.
     function getQuotes(uint256 inAmount, address base, address quote) external view returns (uint256, uint256) {
         uint256 outAmount = _getQuote(inAmount, base, quote);
         return (outAmount, outAmount);
     }
 
-    function _getQuote(uint256 inAmount, address, address) internal view virtual returns (uint256);
+    function _getQuote(uint256, address, address) internal view virtual returns (uint256);
 }

--- a/src/adapter/chainlink/ChainlinkOracle.sol
+++ b/src/adapter/chainlink/ChainlinkOracle.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.23;
 import {IERC20} from "forge-std/interfaces/IERC20.sol";
 import {BaseAdapter, Errors} from "src/adapter/BaseAdapter.sol";
 import {AggregatorV3Interface} from "src/adapter/chainlink/AggregatorV3Interface.sol";
+import {ScaleUtils, Scale} from "src/lib/ScaleUtils.sol";
 
 /// @title ChainlinkOracle
 /// @author Euler Labs (https://www.eulerlabs.com/)
@@ -19,45 +20,27 @@ contract ChainlinkOracle is BaseAdapter {
     /// @notice The maximum allowed age of the price.
     /// @dev Reverts if block.timestamp - updatedAt > maxStaleness.
     uint256 public immutable maxStaleness;
-    /// @notice Whether the feed returns the price of base/quote or quote/base.
-    bool public immutable inverse;
-    /// @dev The scale factor used to convert decimals.
-    uint256 internal immutable scaleFactor;
-    /// @dev Whether the scale factor is applied to the numerator (true) or denominator (false).
-    bool internal immutable scaleNumerator;
+    /// @notice The scale factors used for decimal conversions.
+    Scale internal immutable scale;
 
     /// @notice Deploy a ChainlinkOracle.
     /// @param _base The address of the base asset corresponding to the feed.
     /// @param _quote The address of the quote asset corresponding to the feed.
     /// @param _feed The address of the Chainlink price feed.
     /// @param _maxStaleness The maximum allowed age of the price.
-    /// @param _inverse Whether the feed returns the price of base/quote or quote/base.
     /// @dev Base and quote are not required to correspond to the feed assets.
     /// For example, the ETH/USD feed can be used to price WETH/USDC.
-    constructor(address _base, address _quote, address _feed, uint256 _maxStaleness, bool _inverse) {
+    constructor(address _base, address _quote, address _feed, uint256 _maxStaleness) {
         base = _base;
         quote = _quote;
         feed = _feed;
         maxStaleness = _maxStaleness;
-        inverse = _inverse;
 
         // The scale factor is used to correctly convert decimals.
-        int8 baseDecimals = int8(IERC20(base).decimals());
-        int8 quoteDecimals = int8(IERC20(quote).decimals());
-        int8 feedDecimals = int8(AggregatorV3Interface(feed).decimals());
-        int8 scaleDecimals;
-        if (inverse) {
-            scaleDecimals = feedDecimals + quoteDecimals - baseDecimals;
-        } else {
-            scaleDecimals = feedDecimals + baseDecimals - quoteDecimals;
-        }
-        if (scaleDecimals > 0) {
-            scaleFactor = 10 ** uint8(scaleDecimals);
-            scaleNumerator = inverse;
-        } else {
-            scaleFactor = 10 ** uint8(-scaleDecimals);
-            scaleNumerator = !inverse;
-        }
+        uint8 baseDecimals = IERC20(base).decimals();
+        uint8 quoteDecimals = IERC20(quote).decimals();
+        uint8 feedDecimals = AggregatorV3Interface(feed).decimals();
+        scale = ScaleUtils.calcScale(baseDecimals, quoteDecimals, feedDecimals);
     }
 
     /// @notice Get the quote from the Chainlink feed.
@@ -66,7 +49,7 @@ contract ChainlinkOracle is BaseAdapter {
     /// @param _quote The token that is the unit of account.
     /// @return The converted amount using the Chainlink feed.
     function _getQuote(uint256 inAmount, address _base, address _quote) internal view override returns (uint256) {
-        if (_base != base || _quote != quote) revert Errors.PriceOracle_NotSupported(_base, _quote);
+        bool inverse = ScaleUtils.getDirectionOrRevert(_base, base, _quote, quote);
 
         (, int256 answer,, uint256 updatedAt,) = AggregatorV3Interface(feed).latestRoundData();
         if (answer <= 0) revert Errors.PriceOracle_InvalidAnswer();
@@ -74,7 +57,6 @@ contract ChainlinkOracle is BaseAdapter {
         if (staleness > maxStaleness) revert Errors.PriceOracle_TooStale(staleness, maxStaleness);
 
         uint256 price = uint256(answer);
-        if (scaleNumerator) return (inAmount * scaleFactor) / price;
-        else return (inAmount * price) / scaleFactor;
+        return ScaleUtils.calcOutAmount(inAmount, price, scale, inverse);
     }
 }

--- a/src/adapter/pyth/PythOracle.sol
+++ b/src/adapter/pyth/PythOracle.sol
@@ -5,11 +5,11 @@ import {IERC20} from "forge-std/interfaces/IERC20.sol";
 import {IPyth} from "@pyth/IPyth.sol";
 import {PythStructs} from "@pyth/PythStructs.sol";
 import {BaseAdapter, Errors} from "src/adapter/BaseAdapter.sol";
+import {ScaleUtils, Scale} from "src/lib/ScaleUtils.sol";
 
 /// @title PythOracle
 /// @author Euler Labs (https://www.eulerlabs.com/)
 /// @notice PriceOracle adapter for Pyth pull-based price feeds.
-/// @dev Supports bid-ask pricing with the 95% confidence interval from Pyth.
 contract PythOracle is BaseAdapter {
     /// @dev The confidence interval can be at most (-5%,+5%) wide.
     uint256 internal constant MAX_CONF_WIDTH = 500;
@@ -24,10 +24,10 @@ contract PythOracle is BaseAdapter {
     bytes32 public immutable feedId;
     /// @notice The maximum allowed age of the price.
     uint256 public immutable maxStaleness;
-    /// @notice Whether the feed returns the price of base/quote or quote/base.
-    bool public immutable inverse;
     /// @dev Used for correcting for the decimals of base and quote.
-    int8 internal immutable scaleExponent;
+    uint8 internal immutable baseDecimals;
+    /// @dev Used for correcting for the decimals of base and quote.
+    uint8 internal immutable quoteDecimals;
 
     /// @notice Deploy a PythOracle.
     /// @param _pyth The address of the Pyth oracle proxy.
@@ -35,17 +35,14 @@ contract PythOracle is BaseAdapter {
     /// @param _quote The address of the quote asset corresponding to the feed.
     /// @param _feedId The id of the feed in the Pyth network.
     /// @param _maxStaleness The maximum allowed age of the price.
-    /// @param _inverse Whether the feed returns the price of base/quote or quote/base.
-    constructor(address _pyth, address _base, address _quote, bytes32 _feedId, uint256 _maxStaleness, bool _inverse) {
+    constructor(address _pyth, address _base, address _quote, bytes32 _feedId, uint256 _maxStaleness) {
         pyth = _pyth;
         base = _base;
         quote = _quote;
         feedId = _feedId;
         maxStaleness = _maxStaleness;
-        inverse = _inverse;
-        uint8 baseDecimals = IERC20(_base).decimals();
-        uint8 quoteDecimals = IERC20(_quote).decimals();
-        scaleExponent = inverse ? int8(baseDecimals) - int8(quoteDecimals) : int8(quoteDecimals) - int8(baseDecimals);
+        baseDecimals = IERC20(_base).decimals();
+        quoteDecimals = IERC20(_quote).decimals();
     }
 
     /// @notice Update the price of the Pyth feed.
@@ -55,16 +52,19 @@ contract PythOracle is BaseAdapter {
         IPyth(pyth).updatePriceFeeds{value: msg.value}(updateData);
     }
 
-    /// @notice Get the Pyth price and transform it to a quote.
-    /// @dev Has 4 branches depending on inversion and the sign of the net exponent.
+    /// @notice Fetch the latest Pyth price and transform it to a quote.
+    /// @param inAmount The amount of `base` to convert.
+    /// @param _base The token that is being priced.
+    /// @param _quote The token that is the unit of account.
+    /// @return The converted amount.
     function _getQuote(uint256 inAmount, address _base, address _quote) internal view override returns (uint256) {
-        if (_base != base || _quote != quote) revert Errors.PriceOracle_NotSupported(_base, _quote);
-        PythStructs.Price memory priceStruct = _fetchPriceStruct();
-        uint64 midPrice = uint64(priceStruct.price);
-        int32 exponent = priceStruct.expo + scaleExponent;
+        bool inverse = ScaleUtils.getDirectionOrRevert(_base, base, _quote, quote);
 
-        if (inverse) return _calcOutAmountInverse(inAmount, midPrice, exponent);
-        else return _calcOutAmount(inAmount, midPrice, exponent);
+        PythStructs.Price memory priceStruct = _fetchPriceStruct();
+        uint256 price = uint256(uint64(priceStruct.price));
+
+        Scale scale = ScaleUtils.calcScale(baseDecimals, quoteDecimals, int8(priceStruct.expo));
+        return ScaleUtils.calcOutAmount(inAmount, price, scale, inverse);
     }
 
     /// @notice Get the latest Pyth price and perform sanity checks.
@@ -75,31 +75,5 @@ contract PythOracle is BaseAdapter {
             revert Errors.PriceOracle_InvalidAnswer();
         }
         return p;
-    }
-
-    /// @dev Calculate the `outAmount` for an inverted feed given price and exponent.
-    /// @param inAmount The input amount.
-    /// @param price The price returned by Pyth.
-    /// @param exponent The exponent returned by Pyth plus the scaling exponent.
-    /// Formula: inAmount / (price * 10^exponent).
-    function _calcOutAmountInverse(uint256 inAmount, uint256 price, int32 exponent) internal pure returns (uint256) {
-        if (exponent > 0) {
-            return (inAmount / (price * 10 ** uint32(exponent)));
-        } else {
-            return (inAmount * 10 ** uint32(-exponent) / price);
-        }
-    }
-
-    /// @dev Calculate the `outAmount` for a feed given price and exponent.
-    /// @param inAmount The input amount.
-    /// @param price The price returned by Pyth.
-    /// @param exponent The exponent returned by Pyth plus the scaling exponent.
-    /// Formula: inAmount * price * 10^exponent.
-    function _calcOutAmount(uint256 inAmount, uint256 price, int32 exponent) internal pure returns (uint256) {
-        if (exponent > 0) {
-            return (inAmount * price * 10 ** uint32(exponent));
-        } else {
-            return (inAmount * price / 10 ** uint32(-exponent));
-        }
     }
 }

--- a/src/adapter/redstone/RedstoneCoreOracle.sol
+++ b/src/adapter/redstone/RedstoneCoreOracle.sol
@@ -6,6 +6,7 @@ import {RedstoneDefaultsLib} from "@redstone/evm-connector/core/RedstoneDefaults
 import {PrimaryProdDataServiceConsumerBase} from
     "@redstone/evm-connector/data-services/PrimaryProdDataServiceConsumerBase.sol";
 import {BaseAdapter, Errors} from "src/adapter/BaseAdapter.sol";
+import {ScaleUtils, Scale} from "src/lib/ScaleUtils.sol";
 
 /// @title RedstoneCoreOracle
 /// @author Euler Labs (https://www.eulerlabs.com/)
@@ -13,6 +14,7 @@ import {BaseAdapter, Errors} from "src/adapter/BaseAdapter.sol";
 /// @dev To use the oracle, fetch the update data off-chain,
 /// call `updatePrice` to update `lastPrice` and then call `getQuote`.
 contract RedstoneCoreOracle is PrimaryProdDataServiceConsumerBase, BaseAdapter {
+    uint8 internal constant FEED_DECIMALS = 8;
     /// @notice The address of the base asset corresponding to the feed.
     address public immutable base;
     /// @notice The address of the quote asset corresponding to the feed.
@@ -22,10 +24,8 @@ contract RedstoneCoreOracle is PrimaryProdDataServiceConsumerBase, BaseAdapter {
     bytes32 public immutable feedId;
     /// @notice The maximum allowed age of the price.
     uint256 public immutable maxStaleness;
-    /// @notice Whether the feed returns the price of base/quote or quote/base.
-    bool public immutable inverse;
-    /// @dev The scale factor used to convert decimals.
-    uint256 internal immutable scaleFactor;
+    /// @notice The scale factors used for decimal conversions.
+    Scale internal immutable scale;
     /// @notice The last updated price.
     /// @dev This gets updated after calling `updatePrice`.
     uint208 public lastPrice;
@@ -38,10 +38,9 @@ contract RedstoneCoreOracle is PrimaryProdDataServiceConsumerBase, BaseAdapter {
     /// @param _quote The address of the quote asset corresponding to the feed.
     /// @param _feedId The identifier of the price feed.
     /// @param _maxStaleness The maximum allowed age of the price.
-    /// @param _inverse Whether the feed returns the price of base/quote or quote/base.
     /// @dev Base and quote are not required to correspond to the feed assets.
     /// For example, the ETH/USD feed can be used to price WETH/USDC.
-    constructor(address _base, address _quote, bytes32 _feedId, uint256 _maxStaleness, bool _inverse) {
+    constructor(address _base, address _quote, bytes32 _feedId, uint256 _maxStaleness) {
         if (_maxStaleness < RedstoneDefaultsLib.DEFAULT_MAX_DATA_TIMESTAMP_DELAY_SECONDS) {
             revert Errors.PriceOracle_InvalidConfiguration();
         }
@@ -50,10 +49,9 @@ contract RedstoneCoreOracle is PrimaryProdDataServiceConsumerBase, BaseAdapter {
         quote = _quote;
         feedId = _feedId;
         maxStaleness = _maxStaleness;
-        inverse = _inverse;
-
-        uint8 decimals = IERC20(inverse ? _quote : _base).decimals();
-        scaleFactor = 10 ** decimals;
+        uint8 baseDecimals = IERC20(base).decimals();
+        uint8 quoteDecimals = IERC20(quote).decimals();
+        scale = ScaleUtils.calcScale(baseDecimals, quoteDecimals, FEED_DECIMALS);
     }
 
     /// @notice Ingest a signed update message and cache it on the contract.
@@ -74,11 +72,11 @@ contract RedstoneCoreOracle is PrimaryProdDataServiceConsumerBase, BaseAdapter {
     /// @param _quote The token that is the unit of account.
     /// @return The converted amount using the Redstone feed.
     function _getQuote(uint256 inAmount, address _base, address _quote) internal view override returns (uint256) {
-        if (_base != base || _quote != quote) revert Errors.PriceOracle_NotSupported(_base, _quote);
+        bool inverse = ScaleUtils.getDirectionOrRevert(_base, base, _quote, quote);
+
         uint256 staleness = block.timestamp - lastUpdatedAt;
         if (staleness > maxStaleness) revert Errors.PriceOracle_TooStale(staleness, maxStaleness);
 
-        if (inverse) return (inAmount * scaleFactor) / lastPrice;
-        else return (inAmount * lastPrice) / scaleFactor;
+        return ScaleUtils.calcOutAmount(inAmount, lastPrice, scale, inverse);
     }
 }

--- a/src/adapter/rocketpool/RethOracle.sol
+++ b/src/adapter/rocketpool/RethOracle.sol
@@ -25,8 +25,8 @@ contract RethOracle is BaseAdapter {
     /// @notice Get a quote by querying the exchange rate from the rETH contract.
     /// @dev Calls `getEthValue` for rETH/WETH and `getRethValue` for WETH/rETH.
     /// @param inAmount The amount of `base` to convert.
-    /// @param base The token that is being priced. Either rETH or WETH.
-    /// @param quote The token that is the unit of account. Either WETH or rETH.
+    /// @param base The token that is being priced. Either `rETH` or `WETH`.
+    /// @param quote The token that is the unit of account. Either `WETH` or `rETH`.
     /// @return The converted amount.
     function _getQuote(uint256 inAmount, address base, address quote) internal view override returns (uint256) {
         if (base == reth && quote == weth) {

--- a/src/lib/ScaleUtils.sol
+++ b/src/lib/ScaleUtils.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.23;
+
+import {FixedPointMathLib} from "@solady/utils/FixedPointMathLib.sol";
+import {Errors} from "src/lib/Errors.sol";
+
+type Scale is uint256;
+
+/// @title ScaleUtils
+/// @author Euler Labs (https://www.eulerlabs.com/)
+/// @notice Utilities for handling decimal conversion of unit price feeds.
+library ScaleUtils {
+    /// @notice The maximum allowed exponent for Scale components.
+    /// @dev 38 is the largest integer exponent of 10 that fits in 128 bits.
+    uint256 internal constant MAX_EXPONENT = 38;
+
+    /// @notice Create a `Scale` by packing 2 powers of 10.
+    /// @dev Upper 128 bits occupied by 10^feedExponent.
+    /// Lower 128 bits occupied by 10^priceExponent.
+    /// @return The two scale factors packed in `Scale`.
+    function from(uint8 priceExponent, uint8 feedExponent) internal pure returns (Scale) {
+        if (priceExponent > MAX_EXPONENT || feedExponent > MAX_EXPONENT) {
+            revert Errors.PriceOracle_Overflow();
+        }
+        return Scale.wrap((10 ** feedExponent << 128) | 10 ** priceExponent);
+    }
+
+    /// @notice Calculate the direction of pricing, or revert if no match.
+    /// @param givenBase The base asset supplied by the caller.
+    /// @param base The base asset in the price oracle adapter.
+    /// @param givenQuote The quote asset supplied by the caller.
+    /// @param quote The quote asset in the price oracle adapter.
+    /// @return False if base/quote, true if quote/base else revert.
+    function getDirectionOrRevert(address givenBase, address base, address givenQuote, address quote)
+        internal
+        pure
+        returns (bool)
+    {
+        if (givenBase == base && givenQuote == quote) return false;
+        if (givenBase == quote && givenQuote == base) return true;
+        revert Errors.PriceOracle_NotSupported(givenBase, givenQuote);
+    }
+
+    /// @notice Calculate the scale factors for converting a unit price.
+    /// @param baseDecimals The decimals of the base asset.
+    /// @param quoteDecimals The decimals of the quote asset.
+    /// @param feedDecimals The decimals of the feed, already incorporated into the price.
+    /// @return The scale factors used for price conversions.
+    function calcScale(uint8 baseDecimals, uint8 quoteDecimals, uint8 feedDecimals) internal pure returns (Scale) {
+        return from(quoteDecimals, feedDecimals + baseDecimals);
+    }
+
+    /// @notice Calculate the scale factors for converting a unit price.
+    /// @param baseDecimals The decimals of the base asset.
+    /// @param quoteDecimals The decimals of the quote asset.
+    /// @param priceDecimals The decimals of the feed price, not incorporated into the price.
+    /// @return The scale factors used for price conversions.
+    function calcScale(uint8 baseDecimals, uint8 quoteDecimals, int8 priceDecimals) internal pure returns (Scale) {
+        int8 diff = int8(baseDecimals) - priceDecimals;
+        if (diff > 0) return from(quoteDecimals, uint8(diff));
+        else return from(quoteDecimals + uint8(-diff), 0);
+    }
+
+    /// @notice Convert the price by applying scale factors.
+    /// @param inAmount The amount of `base` to convert.
+    /// @param unitPrice The unit price reported by the feed.
+    /// @param scale The scale factors returned by `calcScale`.
+    /// @param inverse Whether to price base/quote or quote/base.
+    /// @return The resulting outAmount.
+    function calcOutAmount(uint256 inAmount, uint256 unitPrice, Scale scale, bool inverse)
+        internal
+        pure
+        returns (uint256)
+    {
+        uint256 priceScale = (Scale.unwrap(scale) << 128) >> 128;
+        uint256 feedScale = Scale.unwrap(scale) >> 128;
+        if (inverse) {
+            // (inAmount * feedScale) / (priceScale * unitPrice)
+            return FixedPointMathLib.fullMulDiv(inAmount, feedScale, priceScale * unitPrice);
+        } else {
+            // (inAmount * unitPrice * priceScale) / feedScale
+            return FixedPointMathLib.fullMulDiv(inAmount * unitPrice, priceScale, feedScale);
+        }
+    }
+}

--- a/test/fork/adapter/chainlink/ChainlinkOracle.fork.t.sol
+++ b/test/fork/adapter/chainlink/ChainlinkOracle.fork.t.sol
@@ -24,62 +24,38 @@ contract ChainlinkOracleForkTest is ForkTest {
     }
 
     function test_btcEth() public {
-        oracle = new ChainlinkOracle(WBTC, WETH, CHAINLINK_BTC_ETH_FEED, 24 hours, false);
+        oracle = new ChainlinkOracle(WBTC, WETH, CHAINLINK_BTC_ETH_FEED, 24 hours);
         assertApproxEqRel(oracle.getQuote(0.06e8, WBTC, WETH), 1e18, 0.1e18);
-    }
-
-    function test_btcEth_inverse() public {
-        oracle = new ChainlinkOracle(WETH, WBTC, CHAINLINK_BTC_ETH_FEED, 24 hours, true);
         assertApproxEqRel(oracle.getQuote(17e18, WETH, WBTC), 1e8, 0.1e18);
     }
 
     function test_usdcEth() public {
-        oracle = new ChainlinkOracle(USDC, WETH, CHAINLINK_USDC_ETH_FEED, 24 hours, false);
+        oracle = new ChainlinkOracle(USDC, WETH, CHAINLINK_USDC_ETH_FEED, 24 hours);
         assertApproxEqRel(oracle.getQuote(2500e6, USDC, WETH), 1e18, 0.1e18);
-    }
-
-    function test_usdcEth_inverse() public {
-        oracle = new ChainlinkOracle(WETH, USDC, CHAINLINK_USDC_ETH_FEED, 24 hours, true);
         assertApproxEqRel(oracle.getQuote(1e18, WETH, USDC), 2500e6, 0.1e18);
     }
 
     function test_stEthEth() public {
-        oracle = new ChainlinkOracle(STETH, WETH, CHAINLINK_STETH_ETH_FEED, 24 hours, false);
+        oracle = new ChainlinkOracle(STETH, WETH, CHAINLINK_STETH_ETH_FEED, 24 hours);
         assertApproxEqRel(oracle.getQuote(1e18, STETH, WETH), 1e18, 0.1e18);
-    }
-
-    function test_stEthEth_inverse() public {
-        oracle = new ChainlinkOracle(WETH, STETH, CHAINLINK_STETH_ETH_FEED, 24 hours, true);
         assertApproxEqRel(oracle.getQuote(1e18, WETH, STETH), 1e18, 0.1e18);
     }
 
     function test_ethUsd_USDC() public {
-        oracle = new ChainlinkOracle(WETH, USDC, CHAINLINK_ETH_USD_FEED, 24 hours, false);
+        oracle = new ChainlinkOracle(WETH, USDC, CHAINLINK_ETH_USD_FEED, 24 hours);
         assertApproxEqRel(oracle.getQuote(1e18, WETH, USDC), 2500e6, 0.1e18);
-    }
-
-    function test_ethUsd_USDC_inverse() public {
-        oracle = new ChainlinkOracle(USDC, WETH, CHAINLINK_ETH_USD_FEED, 24 hours, true);
         assertApproxEqRel(oracle.getQuote(2500e6, USDC, WETH), 1e18, 0.1e18);
     }
 
     function test_ethUsd_DAI() public {
-        oracle = new ChainlinkOracle(WETH, DAI, CHAINLINK_ETH_USD_FEED, 24 hours, false);
+        oracle = new ChainlinkOracle(WETH, DAI, CHAINLINK_ETH_USD_FEED, 24 hours);
         assertApproxEqRel(oracle.getQuote(1e18, WETH, DAI), 2500e18, 0.1e18);
-    }
-
-    function test_ethUsd_DAI_inverse() public {
-        oracle = new ChainlinkOracle(DAI, WETH, CHAINLINK_ETH_USD_FEED, 24 hours, true);
         assertApproxEqRel(oracle.getQuote(2500e18, DAI, WETH), 1e18, 0.1e18);
     }
 
     function test_ethUsd_GUSD() public {
-        oracle = new ChainlinkOracle(WETH, GUSD, CHAINLINK_ETH_USD_FEED, 24 hours, false);
+        oracle = new ChainlinkOracle(WETH, GUSD, CHAINLINK_ETH_USD_FEED, 24 hours);
         assertApproxEqRel(oracle.getQuote(1e18, WETH, GUSD), 2500e2, 0.1e18);
-    }
-
-    function test_ethUsd_GUSD_inverse() public {
-        oracle = new ChainlinkOracle(GUSD, WETH, CHAINLINK_ETH_USD_FEED, 24 hours, true);
         assertApproxEqRel(oracle.getQuote(2500e2, GUSD, WETH), 1e18, 0.1e18);
     }
 }

--- a/test/fork/adapter/pyth/PythOracle.fork.t.sol
+++ b/test/fork/adapter/pyth/PythOracle.fork.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.23;
 
-import {PYTH, PYTH_ETH_USD_FEED, PYTH_GUSD_USD_FEED, WETH, USDC, DAI, GUSD} from "test/utils/EthereumAddresses.sol";
+import {PYTH, PYTH_ETH_USD_FEED, WETH, USDC, DAI} from "test/utils/EthereumAddresses.sol";
 import {ForkTest} from "test/utils/ForkTest.sol";
 import {PythOracle} from "src/adapter/pyth/PythOracle.sol";
 import {Errors} from "src/lib/Errors.sol";
@@ -14,58 +14,44 @@ contract PythOracleForkTest is ForkTest {
     }
 
     function test_GetQuote_Integrity_WETH_USDC() public {
-        oracle = new PythOracle(PYTH, WETH, USDC, PYTH_ETH_USD_FEED, 1000 days, false);
+        oracle = new PythOracle(PYTH, WETH, USDC, PYTH_ETH_USD_FEED, 1000 days);
         uint256 outAmount = oracle.getQuote(1e18, WETH, USDC);
         assertApproxEqRel(outAmount, 2500e6, 0.1e18);
+        uint256 outAmountInverse = oracle.getQuote(2500e6, USDC, WETH);
+        assertApproxEqRel(outAmountInverse, 1e18, 0.1e18);
     }
 
     function test_GetQuote_Integrity_WETH_DAI() public {
-        oracle = new PythOracle(PYTH, WETH, DAI, PYTH_ETH_USD_FEED, 1000 days, false);
+        oracle = new PythOracle(PYTH, WETH, DAI, PYTH_ETH_USD_FEED, 1000 days);
         uint256 outAmount = oracle.getQuote(1e18, WETH, DAI);
         assertApproxEqRel(outAmount, 2500e18, 0.1e18);
-    }
-
-    function test_GetQuote_Integrity_USDC_WETH_inverse() public {
-        oracle = new PythOracle(PYTH, USDC, WETH, PYTH_ETH_USD_FEED, 1000 days, true);
-        uint256 outAmount = oracle.getQuote(2500e6, USDC, WETH);
-        assertApproxEqRel(outAmount, 1e18, 0.1e18);
-    }
-
-    function test_GetQuote_Integrity_DAI_WETH() public {
-        oracle = new PythOracle(PYTH, DAI, WETH, PYTH_ETH_USD_FEED, 1000 days, true);
-        uint256 outAmount = oracle.getQuote(2500e18, DAI, WETH);
-        assertApproxEqRel(outAmount, 1e18, 0.1e18);
+        uint256 outAmountInverse = oracle.getQuote(2500e18, DAI, WETH);
+        assertApproxEqRel(outAmountInverse, 1e18, 0.1e18);
     }
 
     function test_GetQuotes_Integrity_WETH_USDC() public {
-        oracle = new PythOracle(PYTH, WETH, USDC, PYTH_ETH_USD_FEED, 1000 days, false);
+        oracle = new PythOracle(PYTH, WETH, USDC, PYTH_ETH_USD_FEED, 1000 days);
         (uint256 bidOutAmount, uint256 askOutAmount) = oracle.getQuotes(1e18, WETH, USDC);
         assertApproxEqRel(bidOutAmount, 2500e6, 0.1e18);
         assertApproxEqRel(askOutAmount, 2500e6, 0.1e18);
         assertEq(bidOutAmount, askOutAmount);
+
+        (uint256 bidOutAmountInverse, uint256 askOutAmountInverse) = oracle.getQuotes(2500e6, USDC, WETH);
+        assertApproxEqRel(bidOutAmountInverse, 1e18, 0.1e18);
+        assertApproxEqRel(askOutAmountInverse, 1e18, 0.1e18);
+        assertEq(bidOutAmountInverse, askOutAmountInverse);
     }
 
     function test_GetQuotes_Integrity_WETH_DAI() public {
-        oracle = new PythOracle(PYTH, WETH, DAI, PYTH_ETH_USD_FEED, 1000 days, false);
+        oracle = new PythOracle(PYTH, WETH, DAI, PYTH_ETH_USD_FEED, 1000 days);
         (uint256 bidOutAmount, uint256 askOutAmount) = oracle.getQuotes(1e18, WETH, DAI);
         assertApproxEqRel(bidOutAmount, 2500e18, 0.1e18);
         assertApproxEqRel(askOutAmount, 2500e18, 0.1e18);
         assertEq(bidOutAmount, askOutAmount);
-    }
 
-    function test_GetQuotes_Integrity_USDC_WETH_inverse() public {
-        oracle = new PythOracle(PYTH, USDC, WETH, PYTH_ETH_USD_FEED, 1000 days, true);
-        (uint256 bidOutAmount, uint256 askOutAmount) = oracle.getQuotes(2500e6, USDC, WETH);
-        assertApproxEqRel(bidOutAmount, 1e18, 0.1e18);
-        assertApproxEqRel(askOutAmount, 1e18, 0.1e18);
-        assertEq(bidOutAmount, askOutAmount);
-    }
-
-    function test_GetQuotes_Integrity_DAI_WETH() public {
-        oracle = new PythOracle(PYTH, DAI, WETH, PYTH_ETH_USD_FEED, 1000 days, true);
-        (uint256 bidOutAmount, uint256 askOutAmount) = oracle.getQuotes(2500e18, DAI, WETH);
-        assertApproxEqRel(bidOutAmount, 1e18, 0.1e18);
-        assertApproxEqRel(askOutAmount, 1e18, 0.1e18);
-        assertEq(bidOutAmount, askOutAmount);
+        (uint256 bidOutAmountInverse, uint256 askOutAmountInverse) = oracle.getQuotes(2500e18, DAI, WETH);
+        assertApproxEqRel(bidOutAmountInverse, 1e18, 0.1e18);
+        assertApproxEqRel(askOutAmountInverse, 1e18, 0.1e18);
+        assertEq(bidOutAmountInverse, askOutAmountInverse);
     }
 }

--- a/test/unit/adapter/chainlink/ChainlinkOracle.t.sol
+++ b/test/unit/adapter/chainlink/ChainlinkOracle.t.sol
@@ -14,7 +14,6 @@ contract ChainlinkOracleTest is Test {
         address quote;
         address feed;
         uint256 maxStaleness;
-        bool inverse;
         uint8 baseDecimals;
         uint8 quoteDecimals;
         uint8 feedDecimals;
@@ -36,7 +35,6 @@ contract ChainlinkOracleTest is Test {
         assertEq(oracle.quote(), c.quote);
         assertEq(oracle.feed(), c.feed);
         assertEq(oracle.maxStaleness(), c.maxStaleness);
-        assertEq(oracle.inverse(), c.inverse);
     }
 
     function test_GetQuote_RevertsWhen_NotSupported_Base(FuzzableConfig memory c, address base, uint256 inAmount)
@@ -128,7 +126,6 @@ contract ChainlinkOracleTest is Test {
     ) public {
         _deploy(c);
         _prepareValidRoundData(d);
-        vm.assume(!c.inverse);
         timestamp = bound(timestamp, d.updatedAt, d.updatedAt + c.maxStaleness);
         inAmount = bound(inAmount, 1, type(uint128).max);
 
@@ -136,7 +133,7 @@ contract ChainlinkOracleTest is Test {
         vm.warp(timestamp);
         uint256 outAmount = oracle.getQuote(inAmount, c.base, c.quote);
         uint256 expectedOutAmount =
-            inAmount * uint256(d.answer) / 10 ** (c.feedDecimals + c.baseDecimals - c.quoteDecimals);
+            (inAmount * uint256(d.answer) * 10 ** c.quoteDecimals) / 10 ** (c.feedDecimals + c.baseDecimals);
         assertEq(outAmount, expectedOutAmount);
     }
 
@@ -148,15 +145,14 @@ contract ChainlinkOracleTest is Test {
     ) public {
         _deploy(c);
         _prepareValidRoundData(d);
-        vm.assume(c.inverse);
         timestamp = bound(timestamp, d.updatedAt, d.updatedAt + c.maxStaleness);
         inAmount = bound(inAmount, 1, type(uint128).max);
 
         vm.mockCall(c.feed, abi.encodeWithSelector(AggregatorV3Interface.latestRoundData.selector), abi.encode(d));
         vm.warp(timestamp);
-        uint256 outAmount = oracle.getQuote(inAmount, c.base, c.quote);
+        uint256 outAmount = oracle.getQuote(inAmount, c.quote, c.base);
         uint256 expectedOutAmount =
-            inAmount * 10 ** (c.feedDecimals + c.quoteDecimals - c.baseDecimals) / uint256(d.answer);
+            (inAmount * 10 ** (c.feedDecimals + c.baseDecimals)) / (uint256(d.answer) * 10 ** c.quoteDecimals);
         assertEq(outAmount, expectedOutAmount);
     }
 
@@ -249,7 +245,6 @@ contract ChainlinkOracleTest is Test {
     ) public {
         _deploy(c);
         _prepareValidRoundData(d);
-        vm.assume(!c.inverse);
         timestamp = bound(timestamp, d.updatedAt, d.updatedAt + c.maxStaleness);
         inAmount = bound(inAmount, 1, type(uint128).max);
 
@@ -257,7 +252,7 @@ contract ChainlinkOracleTest is Test {
         vm.warp(timestamp);
         (uint256 bidOutAmount, uint256 askOutAmount) = oracle.getQuotes(inAmount, c.base, c.quote);
         uint256 expectedOutAmount =
-            inAmount * uint256(d.answer) / 10 ** (c.feedDecimals + c.baseDecimals - c.quoteDecimals);
+            (inAmount * uint256(d.answer) * 10 ** c.quoteDecimals) / 10 ** (c.feedDecimals + c.baseDecimals);
         assertEq(bidOutAmount, expectedOutAmount);
         assertEq(askOutAmount, expectedOutAmount);
     }
@@ -270,15 +265,14 @@ contract ChainlinkOracleTest is Test {
     ) public {
         _deploy(c);
         _prepareValidRoundData(d);
-        vm.assume(c.inverse);
         timestamp = bound(timestamp, d.updatedAt, d.updatedAt + c.maxStaleness);
         inAmount = bound(inAmount, 1, type(uint128).max);
 
         vm.mockCall(c.feed, abi.encodeWithSelector(AggregatorV3Interface.latestRoundData.selector), abi.encode(d));
         vm.warp(timestamp);
-        (uint256 bidOutAmount, uint256 askOutAmount) = oracle.getQuotes(inAmount, c.base, c.quote);
+        (uint256 bidOutAmount, uint256 askOutAmount) = oracle.getQuotes(inAmount, c.quote, c.base);
         uint256 expectedOutAmount =
-            inAmount * 10 ** (c.feedDecimals + c.quoteDecimals - c.baseDecimals) / uint256(d.answer);
+            (inAmount * 10 ** (c.feedDecimals + c.baseDecimals)) / (uint256(d.answer) * 10 ** c.quoteDecimals);
         assertEq(bidOutAmount, expectedOutAmount);
         assertEq(askOutAmount, expectedOutAmount);
     }
@@ -293,21 +287,13 @@ contract ChainlinkOracleTest is Test {
 
         c.baseDecimals = uint8(bound(c.baseDecimals, 2, 18));
         c.quoteDecimals = uint8(bound(c.quoteDecimals, 2, 18));
-        c.feedDecimals = uint8(bound(c.feedDecimals, c.inverse ? c.baseDecimals : c.quoteDecimals, 18));
-
-        if (c.inverse) {
-            c.feedDecimals = uint8(bound(c.feedDecimals, c.baseDecimals, 18));
-            vm.assume(c.feedDecimals + c.quoteDecimals - c.baseDecimals < 18);
-        } else {
-            c.feedDecimals = uint8(bound(c.feedDecimals, c.quoteDecimals, 18));
-            vm.assume(c.feedDecimals + c.baseDecimals - c.quoteDecimals < 18);
-        }
+        c.feedDecimals = uint8(bound(c.feedDecimals, 2, 18));
 
         vm.mockCall(c.base, abi.encodeWithSelector(IERC20.decimals.selector), abi.encode(c.baseDecimals));
         vm.mockCall(c.quote, abi.encodeWithSelector(IERC20.decimals.selector), abi.encode(c.quoteDecimals));
         vm.mockCall(c.feed, abi.encodeWithSelector(AggregatorV3Interface.decimals.selector), abi.encode(c.feedDecimals));
 
-        oracle = new ChainlinkOracle(c.base, c.quote, c.feed, c.maxStaleness, c.inverse);
+        oracle = new ChainlinkOracle(c.base, c.quote, c.feed, c.maxStaleness);
     }
 
     function _prepareValidRoundData(FuzzableRoundData memory d) private pure {

--- a/test/unit/adapter/maker/SDaiOracle.t.sol
+++ b/test/unit/adapter/maker/SDaiOracle.t.sol
@@ -17,7 +17,7 @@ contract SDaiOracleTest is Test {
         oracle = new SDaiOracle(DAI, SDAI, POT);
     }
 
-    function test_Constructor_Integrity() public {
+    function test_Constructor_Integrity() public view {
         assertEq(oracle.dai(), DAI);
         assertEq(oracle.sDai(), SDAI);
         assertEq(oracle.dsrPot(), POT);

--- a/test/unit/adapter/pyth/PythOracle.t.sol
+++ b/test/unit/adapter/pyth/PythOracle.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.23;
 
+import {console2} from "forge-std/console2.sol";
 import {Test} from "forge-std/Test.sol";
 import {IERC20} from "forge-std/interfaces/IERC20.sol";
 import {IPyth} from "@pyth/IPyth.sol";
@@ -15,7 +16,6 @@ contract PythOracleTest is Test {
         address quote;
         bytes32 feedId;
         uint256 maxStaleness;
-        bool inverse;
         uint8 baseDecimals;
         uint8 quoteDecimals;
     }
@@ -31,83 +31,111 @@ contract PythOracleTest is Test {
         assertEq(oracle.quote(), c.quote);
         assertEq(oracle.feedId(), c.feedId);
         assertEq(oracle.maxStaleness(), c.maxStaleness);
-        assertEq(oracle.inverse(), c.inverse);
     }
 
-    function test_GetQuote_Integrity_NegExpo(FuzzableConfig memory c, PythStructs.Price memory p, uint256 inAmount)
-        public
-    {
+    function test_GetQuote_Integrity_Concrete(FuzzableConfig memory c) public {
         _bound(c);
-        c.inverse = false;
+        c.baseDecimals = 18;
+        c.quoteDecimals = 6;
         _deploy(c);
 
-        _bound(p);
-        int32 exponent = p.expo + int8(c.quoteDecimals) - int8(c.baseDecimals);
-        vm.assume(exponent <= 0);
         vm.mockCall(
-            PYTH, abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector, c.feedId, c.maxStaleness), abi.encode(p)
+            PYTH,
+            abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector, c.feedId, c.maxStaleness),
+            abi.encode(PythStructs.Price({price: 4000, conf: 1, expo: 0, publishTime: 0}))
         );
-
-        inAmount = bound(inAmount, 0, type(uint64).max);
-        uint256 outAmount = oracle.getQuote(inAmount, c.base, c.quote);
-        assertEq(outAmount, inAmount * uint64(p.price) / 10 ** uint32(-exponent));
+        assertEq(oracle.getQuote(1e18, c.base, c.quote), 4000e6);
+        assertEq(oracle.getQuote(4000e6, c.quote, c.base), 1e18);
     }
 
-    function test_GetQuote_Integrity_PosExpo(FuzzableConfig memory c, PythStructs.Price memory p, uint256 inAmount)
-        public
-    {
+    function test_GetQuote_Integrity_Concrete_2(FuzzableConfig memory c) public {
         _bound(c);
-        c.inverse = false;
+        c.baseDecimals = 18;
+        c.quoteDecimals = 6;
         _deploy(c);
 
-        _bound(p);
-        int32 exponent = p.expo + int8(c.quoteDecimals) - int8(c.baseDecimals);
-        vm.assume(exponent > 0);
         vm.mockCall(
-            PYTH, abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector, c.feedId, c.maxStaleness), abi.encode(p)
+            PYTH,
+            abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector, c.feedId, c.maxStaleness),
+            abi.encode(PythStructs.Price({price: 40, conf: 1, expo: 2, publishTime: 0}))
         );
-
-        inAmount = bound(inAmount, 0, type(uint64).max);
-        uint256 outAmount = oracle.getQuote(inAmount, c.base, c.quote);
-        assertEq(outAmount, inAmount * uint64(p.price) * 10 ** uint32(exponent));
+        assertEq(oracle.getQuote(1e18, c.base, c.quote), 4000e6);
+        assertEq(oracle.getQuote(4000e6, c.quote, c.base), 1e18);
     }
 
-    function test_GetQuote_Integrity_NegExpo_Inv(FuzzableConfig memory c, PythStructs.Price memory p, uint256 inAmount)
-        public
-    {
+    function test_GetQuote_Integrity_Concrete_3(FuzzableConfig memory c) public {
         _bound(c);
-        c.inverse = true;
+        c.baseDecimals = 18;
+        c.quoteDecimals = 6;
         _deploy(c);
 
-        _bound(p);
-        int32 exponent = p.expo - int8(c.quoteDecimals) + int8(c.baseDecimals);
-        vm.assume(exponent <= 0);
         vm.mockCall(
-            PYTH, abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector, c.feedId, c.maxStaleness), abi.encode(p)
+            PYTH,
+            abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector, c.feedId, c.maxStaleness),
+            abi.encode(PythStructs.Price({price: 40, conf: 1, expo: 16, publishTime: 0}))
         );
-
-        inAmount = bound(inAmount, 0, type(uint64).max);
-        uint256 outAmount = oracle.getQuote(inAmount, c.base, c.quote);
-        assertEq(outAmount, inAmount * 10 ** uint32(-exponent) / uint64(p.price));
+        assertEq(oracle.getQuote(1e18, c.base, c.quote), 40e22);
+        assertEq(oracle.getQuote(40e22, c.quote, c.base), 1e18);
     }
 
-    function test_GetQuote_Integrity_PosExpo_Inv(FuzzableConfig memory c, PythStructs.Price memory p, uint256 inAmount)
-        public
-    {
+    function test_GetQuote_Integrity_Concrete_4(FuzzableConfig memory c) public {
         _bound(c);
-        c.inverse = true;
+        c.baseDecimals = 18;
+        c.quoteDecimals = 6;
         _deploy(c);
 
-        _bound(p);
-        int32 exponent = p.expo - int8(c.quoteDecimals) + int8(c.baseDecimals);
-        vm.assume(exponent > 0);
         vm.mockCall(
-            PYTH, abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector, c.feedId, c.maxStaleness), abi.encode(p)
+            PYTH,
+            abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector, c.feedId, c.maxStaleness),
+            abi.encode(PythStructs.Price({price: 400000, conf: 1, expo: -2, publishTime: 0}))
         );
+        assertEq(oracle.getQuote(1e18, c.base, c.quote), 4000e6);
+        assertEq(oracle.getQuote(4000e6, c.quote, c.base), 1e18);
+    }
 
-        inAmount = bound(inAmount, 0, type(uint64).max);
-        uint256 outAmount = oracle.getQuote(inAmount, c.base, c.quote);
-        assertEq(outAmount, inAmount / (uint64(p.price) * 10 ** uint32(exponent)));
+    function test_GetQuote_Integrity_Concrete_5(FuzzableConfig memory c) public {
+        _bound(c);
+        c.baseDecimals = 18;
+        c.quoteDecimals = 6;
+        _deploy(c);
+
+        vm.mockCall(
+            PYTH,
+            abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector, c.feedId, c.maxStaleness),
+            abi.encode(PythStructs.Price({price: 40e16, conf: 1, expo: -16, publishTime: 0}))
+        );
+        assertEq(oracle.getQuote(1e18, c.base, c.quote), 40e6);
+        assertEq(oracle.getQuote(40e6, c.quote, c.base), 1e18);
+    }
+
+    function test_GetQuote_Integrity_Concrete_6(FuzzableConfig memory c) public {
+        _bound(c);
+        c.baseDecimals = 6;
+        c.quoteDecimals = 18;
+        _deploy(c);
+
+        vm.mockCall(
+            PYTH,
+            abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector, c.feedId, c.maxStaleness),
+            abi.encode(PythStructs.Price({price: 40e16, conf: 1, expo: -16, publishTime: 0}))
+        );
+        assertEq(oracle.getQuote(1e6, c.base, c.quote), 40e18);
+        assertEq(oracle.getQuote(40e18, c.quote, c.base), 1e6);
+    }
+
+    function test_GetQuote_Integrity_Concrete_7(FuzzableConfig memory c) public {
+        _bound(c);
+        c.baseDecimals = 2;
+        c.quoteDecimals = 18;
+        _deploy(c);
+
+        vm.mockCall(
+            PYTH,
+            abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector, c.feedId, c.maxStaleness),
+            abi.encode(PythStructs.Price({price: 4, conf: 0, expo: 3, publishTime: 0}))
+        );
+        assertEq(oracle.getQuote(1e2, c.base, c.quote), 4000e18);
+        assertEq(oracle.getQuote(4000e18, c.quote, c.base), 1e2);
     }
 
     function test_GetQuote_RevertsWhen_InvalidBase(FuzzableConfig memory c, uint256 inAmount, address base) public {
@@ -209,86 +237,6 @@ contract PythOracleTest is Test {
         );
         vm.expectRevert(Errors.PriceOracle_InvalidAnswer.selector);
         oracle.getQuote(inAmount, c.base, c.quote);
-    }
-
-    function test_GetQuotes_Integrity_NegExpo(FuzzableConfig memory c, PythStructs.Price memory p, uint256 inAmount)
-        public
-    {
-        _bound(c);
-        c.inverse = false;
-        _deploy(c);
-
-        _bound(p);
-        int32 exponent = p.expo + int8(c.quoteDecimals) - int8(c.baseDecimals);
-        vm.assume(exponent <= 0);
-        vm.mockCall(
-            PYTH, abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector, c.feedId, c.maxStaleness), abi.encode(p)
-        );
-
-        inAmount = bound(inAmount, 0, type(uint64).max);
-        (uint256 bidOutAmount, uint256 askOutAmount) = oracle.getQuotes(inAmount, c.base, c.quote);
-        assertEq(bidOutAmount, inAmount * uint64(p.price) / 10 ** uint32(-exponent));
-        assertEq(askOutAmount, inAmount * uint64(p.price) / 10 ** uint32(-exponent));
-    }
-
-    function test_GetQuotes_Integrity_PosExpo(FuzzableConfig memory c, PythStructs.Price memory p, uint256 inAmount)
-        public
-    {
-        _bound(c);
-        c.inverse = false;
-        _deploy(c);
-
-        _bound(p);
-        int32 exponent = p.expo + int8(c.quoteDecimals) - int8(c.baseDecimals);
-        vm.assume(exponent > 0);
-        vm.mockCall(
-            PYTH, abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector, c.feedId, c.maxStaleness), abi.encode(p)
-        );
-
-        inAmount = bound(inAmount, 0, type(uint64).max);
-        (uint256 bidOutAmount, uint256 askOutAmount) = oracle.getQuotes(inAmount, c.base, c.quote);
-        assertEq(bidOutAmount, inAmount * uint64(p.price) * 10 ** uint32(exponent));
-        assertEq(askOutAmount, inAmount * uint64(p.price) * 10 ** uint32(exponent));
-    }
-
-    function test_GetQuotes_Integrity_NegExpo_Inv(FuzzableConfig memory c, PythStructs.Price memory p, uint256 inAmount)
-        public
-    {
-        _bound(c);
-        c.inverse = true;
-        _deploy(c);
-
-        _bound(p);
-        int32 exponent = p.expo - int8(c.quoteDecimals) + int8(c.baseDecimals);
-        vm.assume(exponent <= 0);
-        vm.mockCall(
-            PYTH, abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector, c.feedId, c.maxStaleness), abi.encode(p)
-        );
-
-        inAmount = bound(inAmount, 0, type(uint64).max);
-        (uint256 bidOutAmount, uint256 askOutAmount) = oracle.getQuotes(inAmount, c.base, c.quote);
-        assertEq(bidOutAmount, inAmount * 10 ** uint32(-exponent) / uint64(p.price));
-        assertEq(askOutAmount, inAmount * 10 ** uint32(-exponent) / uint64(p.price));
-    }
-
-    function test_GetQuotes_Integrity_PosExpo_Inv(FuzzableConfig memory c, PythStructs.Price memory p, uint256 inAmount)
-        public
-    {
-        _bound(c);
-        c.inverse = true;
-        _deploy(c);
-
-        _bound(p);
-        int32 exponent = p.expo - int8(c.quoteDecimals) + int8(c.baseDecimals);
-        vm.assume(exponent > 0);
-        vm.mockCall(
-            PYTH, abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector, c.feedId, c.maxStaleness), abi.encode(p)
-        );
-
-        inAmount = bound(inAmount, 0, type(uint64).max);
-        (uint256 bidOutAmount, uint256 askOutAmount) = oracle.getQuotes(inAmount, c.base, c.quote);
-        assertEq(bidOutAmount, inAmount / (uint64(p.price) * 10 ** uint32(exponent)));
-        assertEq(askOutAmount, inAmount / (uint64(p.price) * 10 ** uint32(exponent)));
     }
 
     function test_GetQuotes_RevertsWhen_InvalidBase(FuzzableConfig memory c, uint256 inAmount, address base) public {
@@ -431,7 +379,7 @@ contract PythOracleTest is Test {
         _bound(c);
         vm.mockCall(c.base, abi.encodeWithSelector(IERC20.decimals.selector), abi.encode(c.baseDecimals));
         vm.mockCall(c.quote, abi.encodeWithSelector(IERC20.decimals.selector), abi.encode(c.quoteDecimals));
-        oracle = new PythOracle(PYTH, c.base, c.quote, c.feedId, c.maxStaleness, c.inverse);
+        oracle = new PythOracle(PYTH, c.base, c.quote, c.feedId, c.maxStaleness);
     }
 
     function _bound(PythStructs.Price memory p) private pure {

--- a/test/unit/adapter/redstone/RedstoneCoreOracle.t.sol
+++ b/test/unit/adapter/redstone/RedstoneCoreOracle.t.sol
@@ -14,7 +14,6 @@ contract RedstoneCoreOracleTest is Test {
         address quote;
         bytes32 feedId;
         uint32 maxStaleness;
-        bool inverse;
         uint8 baseDecimals;
         uint8 quoteDecimals;
     }
@@ -28,7 +27,6 @@ contract RedstoneCoreOracleTest is Test {
         assertEq(oracle.quote(), c.quote);
         assertEq(oracle.feedId(), c.feedId);
         assertEq(oracle.maxStaleness(), c.maxStaleness);
-        assertEq(oracle.inverse(), c.inverse);
         assertEq(oracle.lastPrice(), 0);
         assertEq(oracle.lastUpdatedAt(), 0);
     }
@@ -46,7 +44,7 @@ contract RedstoneCoreOracleTest is Test {
         vm.mockCall(c.quote, abi.encodeWithSelector(IERC20.decimals.selector), abi.encode(c.quoteDecimals));
 
         vm.expectRevert(Errors.PriceOracle_InvalidConfiguration.selector);
-        new RedstoneCoreOracleHarness(c.base, c.quote, c.feedId, c.maxStaleness, c.inverse);
+        new RedstoneCoreOracleHarness(c.base, c.quote, c.feedId, c.maxStaleness);
     }
 
     function test_UpdatePrice_Integrity(FuzzableConfig memory c, uint256 timestamp, uint256 price) public {
@@ -86,7 +84,7 @@ contract RedstoneCoreOracleTest is Test {
         uint256 price
     ) public {
         _deploy(c);
-        inAmount = bound(inAmount, 0, type(uint128).max);
+        inAmount = bound(inAmount, 0, type(uint64).max);
         price = bound(price, 1, type(uint128).max);
         tsUpdatePrice = bound(tsUpdatePrice, c.maxStaleness + 1, type(uint48).max - c.maxStaleness);
         tsGetQuote = bound(tsGetQuote, tsUpdatePrice, tsUpdatePrice + c.maxStaleness);
@@ -97,9 +95,9 @@ contract RedstoneCoreOracleTest is Test {
 
         vm.warp(tsGetQuote);
         uint256 outAmount = oracle.getQuote(inAmount, c.base, c.quote);
-        uint256 expectedOutAmount =
-            c.inverse ? (inAmount * 10 ** c.quoteDecimals) / price : (inAmount * price) / 10 ** c.baseDecimals;
-        assertEq(outAmount, expectedOutAmount);
+        uint256 outAmountInv = oracle.getQuote(inAmount, c.quote, c.base);
+        assertEq(outAmount, (inAmount * price * 10 ** c.quoteDecimals) / 10 ** (8 + c.baseDecimals));
+        assertEq(outAmountInv, (inAmount * 10 ** (8 + c.baseDecimals)) / (price * 10 ** c.quoteDecimals));
     }
 
     function test_GetQuote_RevertsWhen_InvalidBase(FuzzableConfig memory c, uint256 inAmount, address base) public {
@@ -148,7 +146,7 @@ contract RedstoneCoreOracleTest is Test {
         uint256 price
     ) public {
         _deploy(c);
-        inAmount = bound(inAmount, 0, type(uint128).max);
+        inAmount = bound(inAmount, 0, type(uint64).max);
         price = bound(price, 1, type(uint128).max);
         tsUpdatePrice = bound(tsUpdatePrice, c.maxStaleness + 1, type(uint48).max - c.maxStaleness);
         tsGetQuote = bound(tsGetQuote, tsUpdatePrice, tsUpdatePrice + c.maxStaleness);
@@ -159,10 +157,14 @@ contract RedstoneCoreOracleTest is Test {
 
         vm.warp(tsGetQuote);
         (uint256 bidOutAmount, uint256 askOutAmount) = oracle.getQuotes(inAmount, c.base, c.quote);
-        uint256 expectedOutAmount =
-            c.inverse ? (inAmount * 10 ** c.quoteDecimals) / price : (inAmount * price) / 10 ** c.baseDecimals;
+        uint256 expectedOutAmount = (inAmount * price * 10 ** c.quoteDecimals) / 10 ** (8 + c.baseDecimals);
         assertEq(bidOutAmount, expectedOutAmount);
         assertEq(askOutAmount, expectedOutAmount);
+
+        (uint256 bidOutAmountInverse, uint256 askOutAmountInverse) = oracle.getQuotes(inAmount, c.quote, c.base);
+        uint256 expectedOutAmountInverse = (inAmount * 10 ** (8 + c.baseDecimals)) / (price * 10 ** c.quoteDecimals);
+        assertEq(bidOutAmountInverse, expectedOutAmountInverse);
+        assertEq(askOutAmountInverse, expectedOutAmountInverse);
     }
 
     function test_GetQuotes_RevertsWhen_InvalidBase(FuzzableConfig memory c, uint256 inAmount, address base) public {
@@ -208,13 +210,13 @@ contract RedstoneCoreOracleTest is Test {
         c.quote = boundAddr(c.quote);
         vm.assume(c.base != c.quote);
 
-        c.baseDecimals = uint8(bound(c.baseDecimals, 0, 24));
-        c.quoteDecimals = uint8(bound(c.quoteDecimals, 0, 24));
+        c.baseDecimals = uint8(bound(c.baseDecimals, 2, 18));
+        c.quoteDecimals = uint8(bound(c.quoteDecimals, 2, 18));
         c.maxStaleness = uint32(bound(c.maxStaleness, 3 minutes, 24 hours));
 
         vm.mockCall(c.base, abi.encodeWithSelector(IERC20.decimals.selector), abi.encode(c.baseDecimals));
         vm.mockCall(c.quote, abi.encodeWithSelector(IERC20.decimals.selector), abi.encode(c.quoteDecimals));
 
-        oracle = new RedstoneCoreOracleHarness(c.base, c.quote, c.feedId, c.maxStaleness, c.inverse);
+        oracle = new RedstoneCoreOracleHarness(c.base, c.quote, c.feedId, c.maxStaleness);
     }
 }

--- a/test/unit/lib/ScaleUtils.t.sol
+++ b/test/unit/lib/ScaleUtils.t.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.23;
+
+import {Test} from "forge-std/Test.sol";
+import {ScaleUtils, Scale} from "src/lib/ScaleUtils.sol";
+import {Errors} from "src/lib/Errors.sol";
+
+contract ScaleUtilsTest is Test {
+    function test_From_RevertsWhen_PriceExponentOOB(uint8 priceExponent, uint8 feedExponent) public {
+        priceExponent = uint8(bound(priceExponent, ScaleUtils.MAX_EXPONENT + 1, type(uint8).max));
+        feedExponent = uint8(bound(feedExponent, 0, ScaleUtils.MAX_EXPONENT));
+        vm.expectRevert(Errors.PriceOracle_Overflow.selector);
+        ScaleUtils.from(priceExponent, feedExponent);
+    }
+
+    function test_From_RevertsWhen_FeedExponentOOB(uint8 priceExponent, uint8 feedExponent) public {
+        priceExponent = uint8(bound(priceExponent, 0, ScaleUtils.MAX_EXPONENT));
+        feedExponent = uint8(bound(feedExponent, ScaleUtils.MAX_EXPONENT + 1, type(uint8).max));
+        vm.expectRevert(Errors.PriceOracle_Overflow.selector);
+        ScaleUtils.from(priceExponent, feedExponent);
+    }
+
+    function test_GetDirectionOrRevert_Integrity(address base, address quote) public pure {
+        vm.assume(base != quote);
+        assertFalse(ScaleUtils.getDirectionOrRevert(base, base, quote, quote));
+        assertTrue(ScaleUtils.getDirectionOrRevert(quote, base, base, quote));
+    }
+
+    function test_GetDirectionOrRevert_RevertsWhen_InvalidBaseOrQuote(address base, address quote, address other)
+        public
+    {
+        vm.assume(base != quote && quote != other && other != base);
+        vm.expectRevert(abi.encodeWithSelector(Errors.PriceOracle_NotSupported.selector, other, quote));
+        ScaleUtils.getDirectionOrRevert(other, base, quote, quote);
+        vm.expectRevert(abi.encodeWithSelector(Errors.PriceOracle_NotSupported.selector, base, other));
+        ScaleUtils.getDirectionOrRevert(base, base, other, quote);
+    }
+
+    function test_CalcScale_Integrity(uint8 baseDecimals, uint8 quoteDecimals, uint8 feedDecimals) public pure {
+        quoteDecimals = uint8(bound(quoteDecimals, 0, ScaleUtils.MAX_EXPONENT));
+        baseDecimals = uint8(bound(baseDecimals, 0, ScaleUtils.MAX_EXPONENT));
+        feedDecimals = uint8(bound(feedDecimals, 0, ScaleUtils.MAX_EXPONENT - baseDecimals));
+        Scale scale = ScaleUtils.calcScale(baseDecimals, quoteDecimals, feedDecimals);
+
+        uint256 priceScale = (Scale.unwrap(scale) << 128) >> 128;
+        uint256 feedScale = Scale.unwrap(scale) >> 128;
+        assertEq(priceScale, 10 ** quoteDecimals);
+        assertEq(feedScale, 10 ** (feedDecimals + baseDecimals));
+    }
+
+    function test_CalcScale_RevertsWhen_PriceScaleOOB(uint8 baseDecimals, uint8 quoteDecimals, uint8 feedDecimals)
+        public
+    {
+        quoteDecimals = uint8(bound(quoteDecimals, ScaleUtils.MAX_EXPONENT + 1, type(uint8).max));
+        baseDecimals = uint8(bound(baseDecimals, 0, ScaleUtils.MAX_EXPONENT));
+        feedDecimals = uint8(bound(feedDecimals, 0, ScaleUtils.MAX_EXPONENT - baseDecimals));
+        vm.expectRevert(Errors.PriceOracle_Overflow.selector);
+        ScaleUtils.calcScale(baseDecimals, quoteDecimals, feedDecimals);
+    }
+
+    function test_CalcScale_RevertsWhen_FeedScaleOOB(uint8 baseDecimals, uint8 quoteDecimals, uint8 feedDecimals)
+        public
+    {
+        quoteDecimals = uint8(bound(quoteDecimals, 0, ScaleUtils.MAX_EXPONENT));
+        feedDecimals = uint8(
+            bound(
+                feedDecimals,
+                baseDecimals > ScaleUtils.MAX_EXPONENT ? 0 : ScaleUtils.MAX_EXPONENT - baseDecimals + 1,
+                type(uint8).max - baseDecimals
+            )
+        );
+        vm.expectRevert(Errors.PriceOracle_Overflow.selector);
+        ScaleUtils.calcScale(baseDecimals, quoteDecimals, feedDecimals);
+    }
+
+    function test_CalcOutAmount_Integrity() public pure {
+        uint256 unitPrice = 2000e18;
+        uint8 feedDecimals = 18;
+        uint8 baseDecimals = 18;
+        uint8 quoteDecimals = 2;
+
+        Scale scale = ScaleUtils.calcScale(baseDecimals, quoteDecimals, feedDecimals);
+        uint256 inAmount = 4e18;
+        uint256 outAmount = ScaleUtils.calcOutAmount(inAmount, unitPrice, scale, false);
+        uint256 expectedOutAmount = 8000e2;
+        assertEq(outAmount, expectedOutAmount);
+    }
+
+    function test_CalcOutAmount_Integrity_Inverse() public pure {
+        uint256 unitPrice = 2000e18;
+        uint8 feedDecimals = 18;
+        uint8 baseDecimals = 18;
+        uint8 quoteDecimals = 2;
+
+        Scale scale = ScaleUtils.calcScale(baseDecimals, quoteDecimals, feedDecimals);
+        uint256 inAmount = 8000e2;
+        uint256 outAmount = ScaleUtils.calcOutAmount(inAmount, unitPrice, scale, true);
+        uint256 expectedOutAmount = 4e18;
+        assertEq(outAmount, expectedOutAmount);
+    }
+}

--- a/test/utils/RedstoneCoreOracleHarness.sol
+++ b/test/utils/RedstoneCoreOracleHarness.sol
@@ -6,8 +6,8 @@ import {RedstoneCoreOracle} from "src/adapter/redstone/RedstoneCoreOracle.sol";
 contract RedstoneCoreOracleHarness is RedstoneCoreOracle {
     uint256 price;
 
-    constructor(address _base, address _quote, bytes32 _feedId, uint32 _maxStaleness, bool _inverse)
-        RedstoneCoreOracle(_base, _quote, _feedId, _maxStaleness, _inverse)
+    constructor(address _base, address _quote, bytes32 _feedId, uint32 _maxStaleness)
+        RedstoneCoreOracle(_base, _quote, _feedId, _maxStaleness)
     {}
 
     function setPrice(uint256 _price) external {


### PR DESCRIPTION
Duplicated decimal conversion logic in Chainlink/Pyth/Redstone is refactored to `ScaleUtils`. Adapters now call `function calcScale(uint8 baseDecimals, uint8 quoteDecimals, uint8 feedDecimals)` to get `priceScale` and `feedScale`, packed into a wrapped uint256. The inverse pricing logic is now in the library. This allows us to get bidirectional adapters for free.