### PR TITLE
Implement cross pricing adapter

### DIFF
--- a/src/adapter/CrossAdapter.sol
+++ b/src/adapter/CrossAdapter.sol
@@ -21,22 +21,22 @@ contract CrossAdapter is BaseAdapter {
     address public immutable oracleBaseCross;
     /// @notice The oracle that resolves quote/cross and cross/quote.
     /// @dev The oracle MUST be bidirectional.
-    address public immutable oracleQuoteCross;
+    address public immutable oracleCrossQuote;
 
     /// @notice Deploy a CrossAdapter.
     /// @param _base The address of the base asset.
     /// @param _cross The address of the cross/through asset.
     /// @param _quote The address of the quote asset.
     /// @param _oracleBaseCross The oracle that resolves base/cross and cross/base.
-    /// @param _oracleQuoteCross The oracle that resolves quote/cross and cross/quote.
+    /// @param _oracleCrossQuote The oracle that resolves quote/cross and cross/quote.
     /// @dev Both cross oracles MUST be bidirectional.
     /// @dev Does not support bid/ask pricing.
-    constructor(address _base, address _cross, address _quote, address _oracleBaseCross, address _oracleQuoteCross) {
+    constructor(address _base, address _cross, address _quote, address _oracleBaseCross, address _oracleCrossQuote) {
         base = _base;
         cross = _cross;
         quote = _quote;
         oracleBaseCross = _oracleBaseCross;
-        oracleQuoteCross = _oracleQuoteCross;
+        oracleCrossQuote = _oracleCrossQuote;
     }
 
     /// @notice Get a quote by chaining the cross oracles.
@@ -50,11 +50,11 @@ contract CrossAdapter is BaseAdapter {
         bool inverse = ScaleUtils.getDirectionOrRevert(_base, base, _quote, quote);
 
         if (inverse) {
-            inAmount = IPriceOracle(oracleQuoteCross).getQuote(inAmount, quote, cross);
+            inAmount = IPriceOracle(oracleCrossQuote).getQuote(inAmount, quote, cross);
             return IPriceOracle(oracleBaseCross).getQuote(inAmount, cross, base);
         } else {
             inAmount = IPriceOracle(oracleBaseCross).getQuote(inAmount, base, cross);
-            return IPriceOracle(oracleQuoteCross).getQuote(inAmount, cross, quote);
+            return IPriceOracle(oracleCrossQuote).getQuote(inAmount, cross, quote);
         }
     }
 }

--- a/test/unit/adapter/CrossAdapter.t.sol
+++ b/test/unit/adapter/CrossAdapter.t.sol
@@ -29,13 +29,13 @@ contract CrossAdapterTest is Test {
     address CROSS = makeAddr("CROSS");
     address QUOTE = makeAddr("QUOTE");
     StubPriceOracle oracleBaseCross;
-    StubPriceOracle oracleQuoteCross;
+    StubPriceOracle oracleCrossQuote;
     CrossAdapter oracle;
 
     function setUp() public {
         oracleBaseCross = new StubPriceOracle();
-        oracleQuoteCross = new StubPriceOracle();
-        oracle = new CrossAdapter(BASE, CROSS, QUOTE, address(oracleBaseCross), address(oracleQuoteCross));
+        oracleCrossQuote = new StubPriceOracle();
+        oracle = new CrossAdapter(BASE, CROSS, QUOTE, address(oracleBaseCross), address(oracleCrossQuote));
     }
 
     function test_Constructor_Integrity() public view {
@@ -43,10 +43,8 @@ contract CrossAdapterTest is Test {
         assertEq(oracle.cross(), CROSS);
         assertEq(oracle.quote(), QUOTE);
         assertEq(oracle.oracleBaseCross(), address(oracleBaseCross));
-        assertEq(oracle.oracleQuoteCross(), address(oracleQuoteCross));
+        assertEq(oracle.oracleCrossQuote(), address(oracleCrossQuote));
     }
-
-    
 
     function test_GetQuote_Integrity(uint256 inAmount, uint256 priceBaseCross, uint256 priceCrossQuote) public {
         inAmount = bound(inAmount, 0, type(uint128).max);
@@ -54,7 +52,7 @@ contract CrossAdapterTest is Test {
         priceCrossQuote = bound(priceCrossQuote, 1, 1e27);
 
         oracleBaseCross.setPrice(BASE, CROSS, priceBaseCross);
-        oracleQuoteCross.setPrice(CROSS, QUOTE, priceCrossQuote);
+        oracleCrossQuote.setPrice(CROSS, QUOTE, priceCrossQuote);
 
         uint256 expectedOutAmount = inAmount * priceBaseCross / 1e18 * priceCrossQuote / 1e18;
         assertEq(oracle.getQuote(inAmount, BASE, QUOTE), expectedOutAmount);
@@ -67,7 +65,7 @@ contract CrossAdapterTest is Test {
         priceQuoteCross = bound(priceQuoteCross, 1, 1e27);
         priceCrossBase = bound(priceCrossBase, 1, 1e27);
 
-        oracleQuoteCross.setPrice(QUOTE, CROSS, priceQuoteCross);
+        oracleCrossQuote.setPrice(QUOTE, CROSS, priceQuoteCross);
         oracleBaseCross.setPrice(CROSS, BASE, priceCrossBase);
 
         uint256 expectedOutAmount = inAmount * priceQuoteCross / 1e18 * priceCrossBase / 1e18;


### PR DESCRIPTION
CrossAdapter prices a pair by calling through an intermediate oracle.

For example, to price wstETH/USD, CrossAdapter may price wstETH/stETH and then stETH/USD. Another common one is WBTC/USD decomposed into two Chainlink feeds: WBTC/BTC and BTC/USD.

I thought about supporting cross pricing with 3 legs, however I could not come up with examples for pairs that would need that. Only reason is a vault using a non-standard reference asset, but that is too esoteric to make it in scope