### PR TITLE
chore(deps): replace pyth-sdk-solidity submodule with npm package

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,10 +19,6 @@
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
     branch = release-v4.9
-	
-[submodule "lib/pyth-sdk-solidity"]
-	path = lib/pyth-sdk-solidity
-	url = https://github.com/pyth-network/pyth-sdk-solidity
 [submodule "lib/ethereum-vault-connector"]
 	path = lib/ethereum-vault-connector
 	url = https://github.com/euler-xyz/ethereum-vault-connector

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,7 +2,7 @@
 src = "src"
 out = "out"
 test = "test"
-libs = ["lib"]
+libs = ["lib", "node_modules"]
 solc = "0.8.23"
 evm_version = "cancun"
 optimizer = true

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "GPL-2.0-or-later",
       "dependencies": {
+        "@pythnetwork/pyth-sdk-solidity": "^4.1.0",
         "@redstone-finance/evm-connector": "^0.4.0"
       }
     },
@@ -787,6 +788,11 @@
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.4.2.tgz",
       "integrity": "sha512-z0zMCjyhhp4y7XKAcDAi3Vgms4T2PstwBdahiO0+9NaGICQKjynK3wduSRplTgk4LXmoO1yfDGO5RbjKYxtuxA==",
       "license": "MIT"
+    },
+    "node_modules/@pythnetwork/pyth-sdk-solidity": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-4.1.0.tgz",
+      "integrity": "sha512-SPqaWH1fKwYbdTsyTLGuSqCYDEEgCXw0SFW0KaOFRgzcGYcdZY/DYWhedCzFNb9lY/1RTk+ucgTtxO5e3Z1fIg=="
     },
     "node_modules/@redstone-finance/evm-connector": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "Euler Labs",
   "license": "GPL-2.0-or-later",
   "dependencies": {
-    "@redstone-finance/evm-connector": "^0.4.0"
+    "@redstone-finance/evm-connector": "^0.4.0",
+    "@pythnetwork/pyth-sdk-solidity": "^4.1.0"
   }
 }

--- a/remappings.txt
+++ b/remappings.txt
@@ -3,6 +3,6 @@
 @uniswap/v3-periphery/=lib/v3-periphery/
 @redstone/evm-connector/=lib/redstone-oracles-monorepo/packages/evm-connector/contracts/
 @openzeppelin/contracts=lib/openzeppelin-contracts/contracts/
-@pyth/=lib/pyth-sdk-solidity/
+@pyth/=node_modules/@pythnetwork/pyth-sdk-solidity/
 ethereum-vault-connector/=lib/ethereum-vault-connector/src/
 @pendle/core-v2/=lib/pendle-core-v2-public/contracts/


### PR DESCRIPTION
https://github.com/pyth-network/pyth-sdk-solidity

The above git repo is no longer available. Pyth network's crosschain monorepo now recommends using the npm package instead.

https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/ethereum/sdk/solidity#foundry
